### PR TITLE
Add cluster color based on urgency

### DIFF
--- a/Graphs/GeoMap/default.config.js
+++ b/Graphs/GeoMap/default.config.js
@@ -1,6 +1,12 @@
 export const properties = {
     maxZoom: 18,
     minZoom: 3,
+    urgency: [
+      "GREY",
+      "RED",
+      "YELLOW",
+      "BLUE",
+    ],
     mapStyles: [
       {
         "featureType": "administrative",

--- a/README.md
+++ b/README.md
@@ -517,12 +517,14 @@ or
 
 "markerIcon": {
     "default": "default-icon", // optional
+    "defaultUrgency": "GREEN", // optional
     "criteria": [
         {
             "icon": "icon1",
             "fields": {
                 "nsg.status": "deactivated"
-            }
+            },
+            "urgency": "GRAY" // Either of "GREY", "RED", "YELLOW", "BLUE", as per criticaliy.
         },
         {
             "icon": "icon2",

--- a/utils/helpers/icons.js
+++ b/utils/helpers/icons.js
@@ -7,6 +7,7 @@ const icons = {
 };
 
 const defaultIcon = 'nsGatewayBlue';
+const defaultUrgency = 'BLUE';
 
 export default (iconKey = null, data = []) => {
 
@@ -31,6 +32,8 @@ export default (iconKey = null, data = []) => {
    *  }
    */
     let icon;
+    let urgency;
+
     if (iconKey && typeof iconKey === "object") {
       if (iconKey.criteria) {
         iconKey.criteria.forEach(d => {
@@ -48,6 +51,9 @@ export default (iconKey = null, data = []) => {
 
           if (Object.keys(d.fields).length === counter) {
             icon = d.icon;
+            if (d.urgency) {
+              urgency = d.urgency;
+            }
           }
         })
       }
@@ -55,12 +61,25 @@ export default (iconKey = null, data = []) => {
       // if default icon defined in configuration then pick default icon
       if (!icon && iconKey.default)
         icon = iconKey.default;
+
+      if (!urgency && iconKey.defaultUrgency)
+        urgency = iconKey.defaultUrgency;
+
+
     } else {
         icon = iconKey;
     }
 
-    if(!icon)
-        icon = defaultIcon;
+    if (!icon) {
+      icon = defaultIcon;
+    }
 
-    return `${process.env.PUBLIC_URL}/icons/${icons[icon] || icons[defaultIcon]}`;
+    if (!urgency) {
+      urgency = defaultUrgency;
+    }
+
+    return {
+      url: `${process.env.PUBLIC_URL}/icons/${icons[icon] || icons[defaultIcon]}`,
+      urgency,
+    };
 }


### PR DESCRIPTION
@natabal @bmukheja 

Change the color of the cluster icons based on its urgency and update docs
Below is the sample code to set the urgency color in setting file : -

`
        "markerIcon": {

            "default": "nsGatewayBlue",
            "defaultUrgency": "YELLOW",
            "criteria": [
                {
                    "icon": "nsGatewayYellow",
                    "fields": {
                        "color": "yellow"
                    },
                    "urgency": "GREY"
                },
                {
                    "icon": "nsGatewayBlue",
                    "fields": {
                        "color": "green"
                    },
                    "urgency": "GREY"
                },
                {
                    "icon": "nsGatewayRed",
                    "fields": {
                        "color": "red"
                    },
                    "urgency": "GREY"
                }
            ]
        },` 

Note: urgency color should be either of "GREY", "RED", "YELLOW", "BLUE", as per criticaliy