### PR TITLE
[add]: functionality to add/remove column for filter (search bar)

### DIFF
--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -345,6 +345,7 @@ class Table extends AbstractGraph {
                         sortable: columnRow.sort !== false,
                         columnText: columnRow.selection ? "" : (columnRow.label || columnRow.column),
                         columField: index,
+                        filter: columnRow.filter !== false,
                         type: columnRow.selection ? "selection" : "text",
                         style: {
                             textIndent: '2px'
@@ -586,7 +587,7 @@ class Table extends AbstractGraph {
                 return key
             }
         }
-        return false
+        return column;
     }
 
     getColumnNameByKey(key) {
@@ -693,13 +694,14 @@ class Table extends AbstractGraph {
         if(searchBar === false)
             return;
 
-        const search = searchString !== null ? searchString : searchText;
+        const search = searchString !== null ? searchString : searchText,
+            filteroption = headerData.filter( d => d.filter === true);
 
         return (
             <SearchBar
                 data={this.originalData}
                 searchText={search}
-                options={headerData}
+                options={filteroption}
                 handleSearch={this.handleSearch}
                 columns={this.getColumns()}
                 scroll={this.props.scroll}

--- a/README.md
+++ b/README.md
@@ -331,7 +331,8 @@ __columns__ - (Array) Array of columns display in the table. Example -
             "OTHER": "green",
             "DENY": "red"
             },
-            "sort": false // to disable sorting on column
+            "sort": false, // to disable sorting on column
+            "filter": false // hide column from search bar to filter data
         },
         { "column": "protocol", "label": "Proto", "selection": true  } // set `selection: true` to enable autocompleter for values of `protocol` column in search bar and must be string only.
         { "column": "sourceip", "label": "SIP" },


### PR DESCRIPTION
@natabal @bmukheja 

We are already making the filter from columns array in the configuration file.
Just added a feature to hide the filter from search bar i.e `"filter": false`.
You may also set `"selection": true` to enable autocompleter on any column.

Note: docs updated for reference. 

Please let me know if this will not work for you.