### PR TITLE
[css-bug]: fix variationTextGraph content rendering & table font-size issue

### DIFF
--- a/Graphs/SimpleTextGraph/default.config.js
+++ b/Graphs/SimpleTextGraph/default.config.js
@@ -4,15 +4,9 @@ export const properties = {
     borderRadius: "50%",
     titlePosition: "top",
     textAlign: "center",
-    margin: {
-        top: "15px",
-        bottom: "5px",
-        left: "auto",
-        right: "auto"
-    },
     padding: {
-        top: "20px",
-        bottom: "20px",
+        top: "15px",
+        bottom: "15px",
         left: "5px",
         right: "5px"
     },
@@ -20,6 +14,5 @@ export const properties = {
     labelFontSize: "16px",
     defaultFontSize: "25px",
     fontColor: theme.palette.whiteColor,
-    innerWidth: 0.3,
-    innerHeight: 0.4,
+    dimension: 0.4,
 }

--- a/Graphs/SimpleTextGraph/default.config.js
+++ b/Graphs/SimpleTextGraph/default.config.js
@@ -14,5 +14,6 @@ export const properties = {
     labelFontSize: "16px",
     defaultFontSize: "25px",
     fontColor: theme.palette.whiteColor,
-    dimension: 0.4,
+    innerWidth: 0.4,
+    innerHeight: 0.4,
 }

--- a/Graphs/SimpleTextGraph/index.js
+++ b/Graphs/SimpleTextGraph/index.js
@@ -48,8 +48,7 @@ class SimpleTextGraph extends AbstractGraph {
         } = this.props;
 
         const {
-            innerWidth,
-            innerHeight,
+            dimension,
             targetedColumn,
             defaultFontSize
         } = this.getConfiguredProperties();
@@ -59,9 +58,9 @@ class SimpleTextGraph extends AbstractGraph {
 
         const text = this.displayText(data, targetedColumn) || 0
 
-        const blockWidth = width * innerWidth
-        const blockHeight = height * innerHeight
-        const textSize = this.state.fontSize * text.toString().length * 0.7
+        const blockWidth = width * dimension
+        const blockHeight = height * dimension
+        const textSize = this.state.fontSize * text.toString().length * 0.4
 
         if (text.toString().length <= 3 && this.state.fontSize !== defaultFontSize) {
             this.setState({
@@ -92,8 +91,8 @@ class SimpleTextGraph extends AbstractGraph {
             return;
 
         return (
-            <div className ={"simpleText"}
-            style={{ fontSize: labelFontSize }}>
+            <div className="simpleText"
+            style={{ fontSize: labelFontSize, marginBottom: 10 }}>
                 {this.currentTitle()}
             </div>
         );
@@ -118,18 +117,19 @@ class SimpleTextGraph extends AbstractGraph {
         return {};
     }
 
-    renderText = ({blockWidth,
-                      blockHeight,
-                      borderRadius,
-                      stroke,
-                      fontColor,
-                      padding,
-                      colors,
-                      cursor,
-                      data,
-                      targetedColumn,
-                      titlePosition
-                  }) => {
+    renderText = ({
+        blockWidth,
+        blockHeight,
+        borderRadius,
+        stroke,
+        fontColor,
+        colors,
+        cursor,
+        data,
+        padding,
+        targetedColumn,
+        titlePosition
+    }) => {
         return (
             <div style={{
                 width: blockWidth,
@@ -142,17 +142,17 @@ class SimpleTextGraph extends AbstractGraph {
                 fontSize: this.state.fontSize,
                 cursor: cursor,
                 margin: 'auto',
-                marginTop: 10
+                display: 'table',
             }}
             >
                 <div style={{
-                    marginLeft: "auto",
-                    marginRight: "auto",
                     width: blockWidth,
-                    padding: [padding.top, padding.right, padding.bottom, padding.left].join(" "),
                     height: blockHeight,
+                    padding: [padding.top, padding.right, padding.bottom, padding.left].join(" "),
                     display: "table-cell",
-                    verticalAlign: "middle"
+                    verticalAlign: "middle",
+                    textAlign: "center",
+                    whiteSpace: 'nowrap',
                 }}>
                     {this.displayText(data, targetedColumn)}
                     {this.renderTitleIfNeeded(titlePosition, "bottom")}
@@ -170,33 +170,22 @@ class SimpleTextGraph extends AbstractGraph {
         } = this.props;
 
         const {
-            innerHeight,
-            innerWidth,
-            margin,
-            textAlign,
+            dimension,
             titlePosition,
-            labelFontSize
         } = this.getConfiguredProperties();
 
         if (!data || !data.length)
             return this.renderMessage('No data to visualize')
 
         const cursor = onMarkClick ? "pointer" : undefined
-        const blockWidth = width * innerWidth
-        const blockHeight = height * innerHeight
+        const blockWidth = width * dimension
+        const blockHeight = height * dimension
 
         return (
-            <div
-                style={{
-                    margin: [margin.top, margin.right, margin.bottom, margin.left].join(" "),
-                    textAlign: textAlign,
-                    display: "table",
-                    fontSize: labelFontSize
-                }}
+            <div className='center-text'
                 onClick={this.handleMarkerClick}
             >
                 {this.renderTitleIfNeeded(titlePosition, "top")}
-
                 {
                     this.renderText({
                         ...this.getConfiguredProperties(),

--- a/Graphs/SimpleTextGraph/index.js
+++ b/Graphs/SimpleTextGraph/index.js
@@ -48,7 +48,8 @@ class SimpleTextGraph extends AbstractGraph {
         } = this.props;
 
         const {
-            dimension,
+            innerWidth,
+            innerHeight,
             targetedColumn,
             defaultFontSize
         } = this.getConfiguredProperties();
@@ -58,8 +59,8 @@ class SimpleTextGraph extends AbstractGraph {
 
         const text = this.displayText(data, targetedColumn) || 0
 
-        const blockWidth = width * dimension
-        const blockHeight = height * dimension
+        const blockWidth = width * innerWidth
+        const blockHeight = height * innerHeight
         const textSize = this.state.fontSize * text.toString().length * 0.4
 
         if (text.toString().length <= 3 && this.state.fontSize !== defaultFontSize) {
@@ -170,7 +171,8 @@ class SimpleTextGraph extends AbstractGraph {
         } = this.props;
 
         const {
-            dimension,
+            innerHeight,
+            innerWidth,
             titlePosition,
         } = this.getConfiguredProperties();
 
@@ -178,8 +180,8 @@ class SimpleTextGraph extends AbstractGraph {
             return this.renderMessage('No data to visualize')
 
         const cursor = onMarkClick ? "pointer" : undefined
-        const blockWidth = width * dimension
-        const blockHeight = height * dimension
+        const blockWidth = width * innerWidth
+        const blockHeight = height * innerHeight
 
         return (
             <div className='center-text'

--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -276,7 +276,10 @@ class Table extends AbstractGraph {
     }
 
     checkFontsize() {
-        if(this.container && this.container.querySelector('table').clientWidth > this.container.clientWidth) {
+        if(this.container &&
+            this.container.querySelector('table').clientWidth > this.container.clientWidth &&
+            this.state.fontSize >= style.defaultFontsize
+        ) {
             this.decrementFontSize();
         }
     }
@@ -968,9 +971,9 @@ class Table extends AbstractGraph {
         tableData = this.removeHighlighter(tableData)
         
         let showFooter = (totalRecords >= pageSize && hidePagination === true) ? false : true,
-            heightMargin = showFooter ? 100 : 80;
+            heightMargin = showFooter ? 95 : 80;
 
-        heightMargin = searchBar === false ? heightMargin * 0.3 : heightMargin
+        heightMargin = searchBar === false ? heightMargin * 0.2 : heightMargin
         heightMargin = selectColumnOption ? heightMargin + 50 : heightMargin
         heightMargin = configuration.filterOptions ? heightMargin + 50 : heightMargin
 

--- a/Graphs/Table/style.js
+++ b/Graphs/Table/style.js
@@ -8,7 +8,7 @@ const tableStyle = {
     },
     body: {
         overflowY: "auto",
-        overflowX: "hidden"
+        overflowX: "auto"
     },
     headerColumn: {
         fontSize: "12px", 

--- a/SearchBar/index.js
+++ b/SearchBar/index.js
@@ -110,7 +110,7 @@ export default class SearchBar extends React.Component {
         } = this.props
 
         return (
-            <div style={{display: "flex", margin: "10px"}}>
+            <div style={{display: "flex", margin: "5px"}}>
                 <div className="search-label">
                     Search: &nbsp;
                 </div>


### PR DESCRIPTION
Hi @natabal 

CSS fixed on variationTextGraph and table content font size. Please have a look.

[![Screenshot from Gyazo](https://gyazo.com/377129eb8863d1c063a6bd9e07c87b99/raw)](https://gyazo.com/377129eb8863d1c063a6bd9e07c87b99)

[![Screenshot from Gyazo](https://gyazo.com/a7922c3c85a87c1249e8de443c16a694/raw)](https://gyazo.com/a7922c3c85a87c1249e8de443c16a694)

[![Screenshot from Gyazo](https://gyazo.com/5556e9fbe5fce680a59b8fb91f3d2eeb/raw)](https://gyazo.com/5556e9fbe5fce680a59b8fb91f3d2eeb)