### PR TITLE
fix import/first lint error in tableGraph test from upstream

### DIFF
--- a/Graphs/Table/tableGraph.test.js
+++ b/Graphs/Table/tableGraph.test.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import ReactDOM from 'react-dom';
-
 import injectTapEventPlugin from 'react-tap-event-plugin';
-injectTapEventPlugin();
-
 import { getDataAndConfig, getHtml, totalRows, checkRowData, totalColumn, checkTime } from '../testHelper';
 import Table from '.';
+
+injectTapEventPlugin();
 
 const cheerio = require('cheerio');
 


### PR DESCRIPTION
This fixes lint error during CI/CD in tableGraph tests that was causing `vsd-react-ui` build to fail.

```
/home/nn/projects/vsd-react-ui/src/lib/vis-graphs/Graphs/Table/tableGraph.test.js
    8:1   error    Import in body of module; reorder to top    import/first
    9:1   error    Import in body of module; reorder to top    import/first
```