### PR TITLE
Fix slice color issue

### DIFF
--- a/Graphs/AbstractGraph.js
+++ b/Graphs/AbstractGraph.js
@@ -471,7 +471,6 @@ export default class AbstractGraph extends React.Component {
         if (this.isVertical() && this.isBrush()) {
             this.availableHeight = this.availableHeight * 0.75
             this.availableMinHeight = height - (this.availableHeight + (margin.top * 4) + margin.bottom + chartHeightToPixel + this.getXAxisHeight());
-            this.minMarginTop = this.availableHeight + (margin.top * 2) + chartHeightToPixel + this.getXAxisHeight()
         }
     }
 
@@ -484,7 +483,12 @@ export default class AbstractGraph extends React.Component {
     }
 
     getMinMarginTop() {
-        return this.minMarginTop;
+        const {
+            chartHeightToPixel,
+            margin
+        } = this.getConfiguredProperties();
+
+        return this.availableHeight + (margin.top * 2) + chartHeightToPixel + this.getXAxisHeight();
     }
 
     // Check whether to display chart as vertical or horizontal

--- a/Graphs/PieGraph/default.config.js
+++ b/Graphs/PieGraph/default.config.js
@@ -17,5 +17,6 @@ export const properties = {
     stroke: {
         color: theme.palette.whiteColor,
         width: "3px"
-    }
+    },
+    labelCount: 5
 }

--- a/Graphs/PieGraph/index.js
+++ b/Graphs/PieGraph/index.js
@@ -79,7 +79,7 @@ export default class PieGraph extends AbstractGraph {
           otherOptions,
           showZero,
           mappedColors,
-          hideLabel
+          labelCount
         } = this.getConfiguredProperties();
 
 
@@ -206,7 +206,7 @@ export default class PieGraph extends AbstractGraph {
                                       style={{cursor}}
                                       { ...this.tooltipProps(d) }
                                     >
-                                        { hideLabel ? '' : labelText(slice.data) }
+                                        { labelCount >= slices.length ? labelText(slice.data) : '' }
                                     </text>
                                 </g>
                             })

--- a/Graphs/PieGraph/index.js
+++ b/Graphs/PieGraph/index.js
@@ -21,6 +21,7 @@ export default class PieGraph extends AbstractGraph {
         const {
             stroke,
             colorColumn,
+            labelColumn,
             colors,
             legendColumn,
             emptyBoxColor
@@ -33,6 +34,8 @@ export default class PieGraph extends AbstractGraph {
                 value = d[legendColumn]
             } else if (d.hasOwnProperty(colorColumn)) {
                 value = d[colorColumn]
+            } else if (d.hasOwnProperty(labelColumn)) {
+                value = d[labelColumn]
             } else if (d.hasOwnProperty("key")) {
                 value = d["key"]
             }
@@ -75,7 +78,8 @@ export default class PieGraph extends AbstractGraph {
           percentagesFormat,
           otherOptions,
           showZero,
-          mappedColors
+          mappedColors,
+          hideLabel
         } = this.getConfiguredProperties();
 
 
@@ -202,7 +206,7 @@ export default class PieGraph extends AbstractGraph {
                                       style={{cursor}}
                                       { ...this.tooltipProps(d) }
                                     >
-                                        { labelText(slice.data) }
+                                        { hideLabel ? '' : labelText(slice.data) }
                                     </text>
                                 </g>
                             })

--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ __pieOuterRadius__ - Outer radius of the slices
 
 __pieLabelRadius__ - Radius for positioning labels
 
+__percentages__ - (boolean) Show area in percentage in each slice of pie chart. Default is false.
+
+__percentagesFormat__ - Format data for percentage.
+
+__hideLabel__ - (boolean) Hide label of each slice of pie graph. Default is false.
+
 __otherOptions__ - optional object
 - **type** Value must be percentage or number, and default is percentage
 - **limit** As per the type we can define the limit in percentage or slices respectively.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ __percentages__ - (boolean) Show area in percentage in each slice of pie chart. 
 
 __percentagesFormat__ - Format data for percentage.
 
-__hideLabel__ - (boolean) Hide label of each slice of pie graph. Default is false.
+__labelCount__ - (number) Hide labels of pie graph if slice count is greater than labelCount. Default is 5.
 
 __otherOptions__ - optional object
 - **type** Value must be percentage or number, and default is percentage


### PR DESCRIPTION
@natabal 

Issue #87 along with updated docs has been fixed.
Now use `labelCount: 5` to hide the labels if the data size is greater than 5. Default is 5.
You may override labelCount property.

There is one more property which will combine the smaller slices together after a certain count i.e 
`"otherOptions": {
            "label": "Others",
            "limit": 5,
            "type": "number"
        }`

It will show only 6 slices, 5 bigger slice and all the smaller one as just one slice named as "other". 
You can also change the number to percentage as well. You can refer to docs for furhter details.

Respective PR - https://github.com/nuagenetworks/vis-config/pull/25

Also, fixed the another issue for overlapping brush area with legends as shown in the given image: -
[![Screenshot from Gyazo](https://gyazo.com/a756690b47ef3d4e325da2c33c1ad453/raw)](https://gyazo.com/a756690b47ef3d4e325da2c33c1ad453)
 