### PR TITLE
Set min width for brush

### DIFF
--- a/Graphs/AbstractGraph.js
+++ b/Graphs/AbstractGraph.js
@@ -436,9 +436,9 @@ export default class AbstractGraph extends React.Component {
 
         if (this.isBrush() && !this.isVertical()) {
             this.availableWidth = this.availableWidth * (100 - brushArea) / 100
-            this.availableMinWidth = width - (this.availableWidth + this.getLeftMargin() + margin.left + margin.right + margin.left)
+            this.availableMinWidth = width - (this.availableWidth + this.getLeftMargin() + margin.left + margin.right);
+            this.availableMinWidth = this.availableMinWidth > 10 ? this.availableMinWidth : 10;
             this.minMarginLeft = this.availableWidth + this.getLeftMargin() + margin.left;
-
         }
     }
 


### PR DESCRIPTION
@natabal 

I debugged it and found that property **brushArea** is defined as **2**, i.e. 2% of the available width.
Therefore calculating the brush area after reducing margins, it is going in negative.
Now I have fixed the margin issue along with restricting the brush to the min of 10px width.

Please review.