### PR TITLE
[bug]: y label title and ticks overlapping

### DIFF
--- a/Graphs/LineGraph/default.config.js
+++ b/Graphs/LineGraph/default.config.js
@@ -19,5 +19,6 @@ export const properties = {
     ],
     zeroStart: true,
     circleRadius: 5,
-    defaultYColor: theme.palette.greenColor
+    defaultYColor: theme.palette.greenColor,
+    chartWidthToPixel: 7,
 }

--- a/Graphs/LineGraph/index.js
+++ b/Graphs/LineGraph/index.js
@@ -200,7 +200,13 @@ class LineGraph extends XYGraph {
         let xAxisHeight       = xLabel ? chartHeightToPixel : 0;
         let legendWidth       = legend.show ? this.longestLabelLength(filterDatas, legendFn) * chartWidthToPixel : 0;
 
-        let yLabelWidth       = this.longestLabelLength(filterDatas, yLabelFn, yTickFormat);
+        let yLabelWidth = 0;
+        if (yTicksLabel && typeof yTicksLabel === 'object') {
+            yLabelWidth = this.longestLabelLength(Object.values(yTicksLabel));
+        } else {
+            yLabelWidth = this.longestLabelLength(filterDatas, yLabelFn, yTickFormat);
+        }
+
         yLabelWidth = (yLabelWidth > yLabelLimit ?  yLabelLimit + appendCharLength : yLabelWidth)* chartWidthToPixel
         let leftMargin        = margin.left + yLabelWidth;
         let availableWidth    = width - (margin.left + margin.right + yLabelWidth);
@@ -275,8 +281,8 @@ class LineGraph extends XYGraph {
                 defaultYvalue = horizontalLineData[defaultY.column] || null
             }
 
-            startRange = startRange > defaultYvalue ? defaultYvalue - 1 : startRange
-            endRange = endRange < defaultYvalue ? defaultYvalue + 1 : endRange
+            startRange = startRange > defaultYvalue ? Math.floor(defaultYvalue / 10) * 10 : startRange
+            endRange = endRange < defaultYvalue ? Math.ceil(defaultYvalue / 10) * 10 : endRange
             yScale.domain([startRange, endRange]);
 
         }


### PR DESCRIPTION
@natabal 

Following bugs has been fixed in this PR - 
1) Spacing issue between Y label title and Y label ticks.
2) Calculate label size for manually defined `yTicksLabel` values.

Also, I have added `"yTicks": 5` to avoid collision among ticks. PR for the same is [#39](https://github.com/nuagenetworks/vis-config/pull/39)

You may also reduce the y tick font size by using the combination of `yTickFontSize` and `chartWidthToPixel` property. The default font size is `12` px (in number).
