### PR TITLE
Add label setting properties

### DIFF
--- a/Graphs/PieGraph/index.js
+++ b/Graphs/PieGraph/index.js
@@ -84,7 +84,9 @@ export default class PieGraph extends AbstractGraph {
           otherOptions,
           showZero,
           mappedColors,
-          labelCount
+          labelCount,
+          labelLimit,
+          labelFontSize,
         } = this.getConfiguredProperties();
 
 
@@ -159,7 +161,7 @@ export default class PieGraph extends AbstractGraph {
         const pie    = d3.pie().value(value).sort(null);
         const slices = pie(data);
 
-        const labelText = (() => {
+        const getLabelText = (() => {
             if (percentages) {
                 const percentageFormat = d3.format(percentagesFormat || ",.2%");
                 const sum              = d3.sum(data, value);
@@ -194,6 +196,9 @@ export default class PieGraph extends AbstractGraph {
                                 {
                                     slices.map((slice, i) => {
                                         const d = slice.data;
+                                        const labelFullText = labelCount >= slices.length ? getLabelText(d) : '';
+                                        const isTruncate = labelFullText.length > labelLimit;
+                                        const labelText = isTruncate ? `${labelFullText.substr(0, labelLimit)}...` : labelFullText;
 
                                         // Set up clicking and cursor style.
                                         const { onClick, cursor } = (
@@ -223,21 +228,26 @@ export default class PieGraph extends AbstractGraph {
                                             dy=".35em"
                                             fill={ fontColor }
                                             onClick={ onClick }
-                                            style={{cursor}}
+                                            style={{cursor, fontSize: labelFontSize}}
                                             { ...this.tooltipProps(d) }
                                             >
-                                                { labelCount >= slices.length ? labelText(slice.data) : '' }
+                                                <title>{isTruncate ? labelFullText : ''}</title>
+                                                { labelText }
                                             </text>
                                         </g>
                                     })
                                 }
                             </g>
-                            {this.renderLegend(data, legend, getColor, label, legendHeight)}
+                            {this.renderLegend(data, legend, getColor, label)}
                         </svg>
                     </div>
-                    <div className='legendContainer' style={style.legendStyle}>
-                        {this.renderLegend(data, legend, getColor, label)}
-                    </div>
+                    {
+                        legend && legend.separate && (
+                            <div className='legendContainer' style={style.legendStyle}>
+                                {this.renderLegend(data, legend, getColor, label)}
+                            </div>
+                        )
+                    }
                 </div>
             </div>
         );

--- a/Graphs/defaultProperties.js
+++ b/Graphs/defaultProperties.js
@@ -38,6 +38,8 @@ export default {
         circleSize: 4,              // Size in pixel of the circle
         labelOffset: 2,             // Space in pixels between the circle and the label
     },
+    labelFontSize: 10,
+    labelLimit: 10,
     yLabelLimit: 20,
     xLabelLimit: 10,
     xLabelRotate: true,

--- a/README.md
+++ b/README.md
@@ -302,6 +302,10 @@ __percentagesFormat__ - Format data for percentage.
 
 __labelCount__ - (number) Hide labels of pie graph if slice count is greater than labelCount. Default is 5.
 
+__labelFontSize__ - (number) font size of the label. Default is 10.
+
+__labelLimit__ - (numeric) number of character need to display. Default is 10. After 10 character `...` is append with tooltip of full character for each label.
+
 __otherOptions__ - optional object
 - **type** Value must be percentage or number, and default is percentage
 - **limit** As per the type we can define the limit in percentage or slices respectively.


### PR DESCRIPTION
@natabal 

Added following properties for labels - 
`labelFontSize`:  change the font-size of labels. The default is 10px.
`labelLimit`: Add a limit to show label character, after the defined label character `...` is appended with a tooltip of full character for each label. The default limit is 10.
Please have a look.
