### PR TITLE
Percentage overflow in Y-Axis

### DIFF
--- a/Graphs/AbstractGraph.js
+++ b/Graphs/AbstractGraph.js
@@ -221,18 +221,25 @@ export default class AbstractGraph extends React.Component {
         return scale;
     }
 
-    updateYExtent(yExtent, zeroStart) {
-        let padding = 0.10;
+    updateYExtent(yExtent) {
+        const { zeroStart, yRangePadding } = this.getConfiguredProperties();
 
+        
         if (zeroStart && yExtent[0] > 0) {
             yExtent[0] = 0;
         }
-
+        
         if (zeroStart && yExtent[1] < 0) {
             yExtent[1] = 0;
         }
 
+        if (!yRangePadding) {
+            return yExtent;
+        }
+        
+        let padding = 0.10;
         let diff = Math.floor((yExtent[1] - yExtent[0]) * padding);
+
 
         yExtent[0] = (yExtent[0] >= 0 && (yExtent[0] - diff) < 0) ? 0 : yExtent[0] - diff;
         yExtent[1] = (yExtent[1] <= 0 && (yExtent[1] + diff) > 0) ? 0 : yExtent[1] + diff;

--- a/Graphs/LineGraph/index.js
+++ b/Graphs/LineGraph/index.js
@@ -106,7 +106,7 @@ class LineGraph extends XYGraph {
                     }
 
                     flatData.push(Object.assign({
-                        [this.yValue]: 100,//d[ld['value']],
+                        [this.yValue]: d[ld['value']],
                         [this.yKey]: key
                     }, d));
                 });
@@ -235,7 +235,6 @@ class LineGraph extends XYGraph {
         let range = extent(filterDatas, yLabelFn)
 
         let yExtent = this.updateYExtent(range);
-        console.error("yExtent", yExtent)
         let xScale;
 
         if (dateHistogram) {
@@ -306,7 +305,7 @@ class LineGraph extends XYGraph {
         }
 
         if(yTicks){
-            //yAxis.ticks(yTicks);
+            yAxis.ticks(yTicks);
         }
 
         if (yTicksLabel && typeof yTicksLabel === 'object') {

--- a/Graphs/LineGraph/index.js
+++ b/Graphs/LineGraph/index.js
@@ -64,7 +64,6 @@ class LineGraph extends XYGraph {
           yTickSizeInner,
           yTickSizeOuter,
           brushEnabled,
-          zeroStart,
           circleRadius,
           defaultY,
           defaultYColor,
@@ -107,7 +106,7 @@ class LineGraph extends XYGraph {
                     }
 
                     flatData.push(Object.assign({
-                        [this.yValue]: d[ld['value']],
+                        [this.yValue]: 100,//d[ld['value']],
                         [this.yKey]: key
                     }, d));
                 });
@@ -235,8 +234,8 @@ class LineGraph extends XYGraph {
 
         let range = extent(filterDatas, yLabelFn)
 
-        let yExtent = this.updateYExtent(range, zeroStart);
-
+        let yExtent = this.updateYExtent(range);
+        console.error("yExtent", yExtent)
         let xScale;
 
         if (dateHistogram) {
@@ -280,7 +279,6 @@ class LineGraph extends XYGraph {
                 horizontalLineData = this.props[dataSource] && this.props[dataSource].length ? this.props[dataSource][0] : {}
                 defaultYvalue = horizontalLineData[defaultY.column] || null
             }
-
             startRange = startRange > defaultYvalue ? Math.floor(defaultYvalue / 10) * 10 : startRange
             endRange = endRange < defaultYvalue ? Math.ceil(defaultYvalue / 10) * 10 : endRange
             yScale.domain([startRange, endRange]);
@@ -308,7 +306,7 @@ class LineGraph extends XYGraph {
         }
 
         if(yTicks){
-            yAxis.ticks(yTicks);
+            //yAxis.ticks(yTicks);
         }
 
         if (yTicksLabel && typeof yTicksLabel === 'object') {

--- a/Graphs/XYGraph.js
+++ b/Graphs/XYGraph.js
@@ -70,12 +70,11 @@ export default class XYGraph extends AbstractGraph {
           dateHistogram,
           xColumn,
           yColumn,
-          zeroStart
         } = this.getConfiguredProperties();
 
         const xLabelFn = (d) => d[xColumn];
         const yLabelFn = (d) => parseFloat(d[customYColumn ? customYColumn : yColumn]);
-        const yExtent  = this.updateYExtent(extent(data, yLabelFn), zeroStart);
+        const yExtent  = this.updateYExtent(extent(data, yLabelFn));
 
         this.scale = {};
 

--- a/Graphs/defaultProperties.js
+++ b/Graphs/defaultProperties.js
@@ -61,4 +61,6 @@ export default {
         theme.palette.orangeBlindColor,
         theme.palette.mauveColor,
     ],
+    zeroStart: true,
+    yRangePadding: false,
 }

--- a/Graphs/defaultProperties.js
+++ b/Graphs/defaultProperties.js
@@ -62,5 +62,5 @@ export default {
         theme.palette.mauveColor,
     ],
     zeroStart: true,
-    yRangePadding: false,
+    yRangePadding: true,
 }

--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ __x-axis__ __and__ __y-axis__ - (Supported Graphs - BarGraph, PieGraph, AreaGrap
 - **yTickGrid** (boolean) If set to `true` then the complete grid will be drawn
 - **yTickSizeInner** If size is specified, sets the inner tick size to the specified value and returns the axis.
 - **yTickSizeOuter** If size is specified, sets the outer tick size to the specified value and returns the axis.
+- **zeroStart** (boolean) eg. if the value is from range say 30 to 89 and zeroStart is enabled, then this will change the range to 0 to 89. Default value of zeroStart is "true", and currently applicable for line and area graph.
+- **yRangePadding** (boolean) default value is ```false```, if property is enabled then this will add padding around the min and max range, say min and max  range is 34 to 83, then this will change it to 30 to 90.
+
+
 # Graph specific configuration
 
 ## *BarGraph*

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ __x-axis__ __and__ __y-axis__ - (Supported Graphs - BarGraph, PieGraph, AreaGrap
 - **yTickSizeInner** If size is specified, sets the inner tick size to the specified value and returns the axis.
 - **yTickSizeOuter** If size is specified, sets the outer tick size to the specified value and returns the axis.
 - **zeroStart** (boolean) eg. if the value is from range say 30 to 89 and zeroStart is enabled, then this will change the range to 0 to 89. Default value of zeroStart is "true", and currently applicable for line and area graph.
-- **yRangePadding** (boolean) default value is ```false```, if property is enabled then this will add padding around the min and max range, say min and max  range is 34 to 83, then this will change it to 30 to 90.
+- **yRangePadding** (boolean) default value is `true`, if property is enabled then this will add padding around the min and max range, say min and max  range is 34 to 83, then this will change it to 30 to 90.
 
 
 # Graph specific configuration


### PR DESCRIPTION
@natabal 

Fixed percentage overflow issue in the y-axis.
Added the following properties to handle percentage overflow: -
- **zeroStart** (boolean) eg. if the value is from range say 30 to 89 and zeroStart is enabled, then this will change the range to 0 to 89. Default value of zeroStart is "true", and currently applicable for line and area graph.
- **yRangePadding** (boolean) default value is ```false```, if property is enabled then this will add padding around the min and max range, say min and max  range is 34 to 83, then this will change it to 30 to 90.