### PR TITLE
Add custom sorting for stacked bar graph

### DIFF
--- a/Graphs/DynamicBarGraph/index.js
+++ b/Graphs/DynamicBarGraph/index.js
@@ -118,7 +118,8 @@ class BarGraph extends XYGraph {
       xColumn,
       yColumn,
       stackColumn,
-      otherOptions
+      otherOptions,
+      stackSequence
     } = this.getConfiguredProperties()
  
     if (this.isVertical()) {
@@ -137,7 +138,7 @@ class BarGraph extends XYGraph {
       metric: this.metric,
       stack: this.stack,
       otherOptions,
-      vertical: this.isVertical()
+      stackSequence,
     })
 
     // check condition to apply brush on chart

--- a/README.md
+++ b/README.md
@@ -241,7 +241,11 @@ __stackColumn__ - Used to show stacked data in bars. E.g-
 ```
 ![stacked](https://user-images.githubusercontent.com/26645756/36251630-d603b8a0-1267-11e8-8efe-502c1046c7a8.png)
 
-__stackColumn__ (optional) To show stacked Bar Charts
+__stackSequence__ (array) sorting of stacked data manually. Only applicable when `stackColumn` is enable. It is an optional property.  E.g -
+```javascript
+"stackSequence": ['GOOGLE', 'NETFLIX']
+```
+In above example,  'google' & 'netflix' will display at the start of stacked bars and rest data will be sorted `asc` or `desc` order as per defined in sorting.
 
 __brush__ (number) To enble brushing with pre selected bars.Currently support in bar graph and heatmap graph. E.g -
 ```javascript

--- a/utils/helpers/barGraph/dataParser.js
+++ b/utils/helpers/barGraph/dataParser.js
@@ -7,7 +7,7 @@ export default ({
   metric,
   stack,
   otherOptions,
-  vertical
+  stackSequence = null
     }) => {
 
   return nestStack({
@@ -16,7 +16,8 @@ export default ({
         data: nest({
           data,
           key: dimension,
-          sortColumn: stack
+          sortColumn: stack,
+          sequence: stackSequence
         }),
         stackColumn: metric
       }),

--- a/utils/helpers/sorter.js
+++ b/utils/helpers/sorter.js
@@ -7,14 +7,43 @@ export default ({
     order,
     sequence = null
   }) => {
-  return (a, b) => {
+
+    return (a, b) => {
     let sortOrder = `${sequence ? 'SEQ' : ''}${order || 'ASC'}`
     
     const operations = {
       'ASC': () => +(a[column] > b[column]),
       'DESC': () => +(a[column] < b[column]),
-      'SEQASC': () => (sequence.indexOf(a[column]) - sequence.indexOf(b[column])),
-      'SEQDESC': () => (sequence.indexOf(b[column]) - sequence.indexOf(a[column]))
+      'SEQASC': () => {
+        if(sequence.indexOf(a[column]) >= 0 && sequence.indexOf(b[column]) >= 0) {
+          return sequence.indexOf(a[column]) - sequence.indexOf(b[column]);
+        }
+
+        if(sequence.indexOf(a[column]) >= 0) {
+          return -1;
+        }
+
+        if(sequence.indexOf(b[column]) >= 0) {
+          return 1;
+        }
+
+        return +(a[column] > b[column]);
+      },
+      'SEQDESC': () => {
+        if(sequence.indexOf(a[column]) >= 0 && sequence.indexOf(b[column]) >= 0) {
+          return sequence.indexOf(a[column]) - sequence.indexOf(b[column]);
+        }
+
+        if(sequence.indexOf(a[column]) >= 0) {
+          return -1;
+        }
+
+        if(sequence.indexOf(b[column]) >= 0) {
+          return 1;
+        }
+
+        return +(a[column] < b[column]);
+      }
     }
 
     return a[column] === b[column]


### PR DESCRIPTION
@natabal 

Added `stackSequence` property for sorting stacked data manually.
If you provide any value(s) in `stackSequence` array then it will come first in the stacked list and rest values will be sorted `asc/desc`  as provided by default. Please have a look.