### PR TITLE
Added check to get default attributes name , description to show on rect node when no context name available

### DIFF
--- a/Graphs/TreeGraph/default.config.js
+++ b/Graphs/TreeGraph/default.config.js
@@ -70,6 +70,14 @@ export const properties = {
                 'name': true,
                 'description': true
             },
+            vminterface: {
+                'name': true,
+                'description': true
+            },
+            default: {
+                'name': true,
+                'description': true
+            }
         }
     },
     margin: {
@@ -79,7 +87,7 @@ export const properties = {
         left: 90
     },
     transformAttr: {
-        translate: [30, -150],
+        translate: [30, -80],
         scale: []
     }
 }

--- a/Graphs/TreeGraph/index.js
+++ b/Graphs/TreeGraph/index.js
@@ -273,7 +273,8 @@ class TreeGraph extends AbstractGraph {
 
         let img = this.fetchImage(d.data.apiData, d.data.contextName);
         const rectColorText = d.children || d.data.clicked ? rectNode.selectedTextColor : rectNode.defaultTextColor
-        const colmAttr = rectNode['attributesToShow'][d.data.contextName];
+        const colmAttr = rectNode['attributesToShow'][d.data.contextName] ? rectNode['attributesToShow'][d.data.contextName] : rectNode['attributesToShow']['default'];
+        
         const displayName = (d.data.name) ? d.data.name.length > 10 ? `${d.data.name.substring(0,10)}...` : d.data.name : 'No Name given';
         const displayDesc = (d.data.description) ? d.data.description.length > 25 ? `${d.data.description.substring(0,25)}...` : d.data.description : commonEN.general.noDescription;
 


### PR DESCRIPTION
There is attributesToShow key in topology.json config file where we added attributes to show based on contextName like for domain we will show name and description.
Similary the error was vminterface where no key added for this context name.

So I added attributes for vminterface and set the "default": { "name": true,"description": true} also if no context available in config file.