### PR TITLE
[Bug]: Fix duartion format issue #140

### DIFF
--- a/Graphs/LineGraph/index.js
+++ b/Graphs/LineGraph/index.js
@@ -14,11 +14,16 @@ import {
     merge,
     event
 } from "d3";
+import moment from 'moment';
+import momentDuration from 'moment-duration-format';
 
 import XYGraph from "../XYGraph";
 import { nest } from "../../utils/helpers"
 import {properties} from "./default.config";
 
+momentDuration(moment);
+
+const duration = "duration";
 class LineGraph extends XYGraph {
 
     yKey   = 'columnType'
@@ -59,6 +64,7 @@ class LineGraph extends XYGraph {
           xTickSizeOuter,
           yColumn,
           yTickFormat,
+          yTickFormatType,
           yTickGrid,
           yTicks,
           yTickSizeInner,
@@ -224,7 +230,7 @@ class LineGraph extends XYGraph {
         if (yTicksLabel && typeof yTicksLabel === 'object') {
             yLabelWidth = this.longestLabelLength(Object.values(yTicksLabel));
         } else {
-            yLabelWidth = this.longestLabelLength(filterDatas, yLabelFn, yTickFormat);
+            yLabelWidth = this.longestLabelLength(filterDatas, yLabelFn, (yTickFormatType !== duration) ? yTickFormat : null);
         }
 
         yLabelWidth = (yLabelWidth > yLabelLimit ?  yLabelLimit + appendCharLength : yLabelWidth)* chartWidthToPixel
@@ -321,8 +327,9 @@ class LineGraph extends XYGraph {
           .tickSizeInner(yTickGrid ? -availableWidth : yTickSizeInner)
           .tickSizeOuter(yTickSizeOuter);
 
-        if(yTickFormat){
-            yAxis.tickFormat(format(yTickFormat));
+        if (yTickFormat) {
+            const yAxisTickFormat = (yTickFormatType === duration) ? (d) => moment.duration(d).format(yTickFormat, { trim: false }) : format(yTickFormat);
+            yAxis.tickFormat(yAxisTickFormat);
         }
 
         if(yTicks){

--- a/README.md
+++ b/README.md
@@ -210,7 +210,9 @@ __x-axis__ __and__ __y-axis__ - (Supported Graphs - BarGraph, PieGraph, AreaGrap
 - **yLabel** y-axis title
 - **yTicks** number of ticks to use on y-axis
 - **yTickFormat** [d3 format](https://github.com/d3/d3-format) style to display y-axis labels
-- **yTickFormatType** If y axis data is in duration(miliseconds) then set `yTickFormatType: 'duration'` and define format in `yTickFormat` property to make it readable. E.g -
+- **yTickFormatType** If y axis data is in duration(miliseconds) then set `yTickFormatType: 'duration'` and define format in `yTickFormat` property to make it readable. Here is the link for the duration format - https://www.npmjs.com/package/moment-duration-format.
+
+E.g -
 ```javascript
     "data": {
     ...

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ __Tolltip__ - If you want to add tooltips on an existing configuration ? Update 
   - **column*** - attribute name to use to display the value
   - **label** - tooltip label. If not specified, column will be used.
   - **format** - [d3 format](https://github.com/d3/d3-format) style to display the column value
+  - **duration** - used to dispaly duration in date time format. You may set the format as per your choice.
 
 ```javascript
 {
@@ -125,7 +126,8 @@ __Tolltip__ - If you want to add tooltips on an existing configuration ? Update 
         // ...
         "tooltip": [
             { "column": "L7Classification", "label": "L7 Signature" },
-            { "column": "Sum of MB", "format": ",.2s"}
+            { "column": "Sum of MB", "format": ",.2s"},
+            { "column": "duration", "label": "Value", "duration": "h [hrs], m [min], s [sec]"}
         ]
     }
     // ...

--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ __x-axis__ __and__ __y-axis__ - (Supported Graphs - BarGraph, PieGraph, AreaGrap
 - **yLabel** y-axis title
 - **yTicks** number of ticks to use on y-axis
 - **yTickFormat** [d3 format](https://github.com/d3/d3-format) style to display y-axis labels
+- **yTickFormatType** If y axis data is in duration(miliseconds) then set `yTickFormatType: 'duration'` and define format in `yTickFormat` property to make it readable. E.g -
+```javascript
+    "data": {
+    ...
+    "yTickFormat": "mm:ss",
+    "yTickFormatType": "duration",
+    ...
+    }
+```
+
 - **yTickGrid** (boolean) If set to `true` then the complete grid will be drawn
 - **yTickSizeInner** If size is specified, sets the inner tick size to the specified value and returns the axis.
 - **yTickSizeOuter** If size is specified, sets the outer tick size to the specified value and returns the axis.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ __Tolltip__ - If you want to add tooltips on an existing configuration ? Update 
         "tooltip": [
             { "column": "L7Classification", "label": "L7 Signature" },
             { "column": "Sum of MB", "format": ",.2s"},
-            { "column": "duration", "label": "Value", "duration": "h [hrs], m [min], s [sec]"}
+            { "column": "timestamp", "label": "Value", "duration": "h [hrs], m [min], s [sec]"}
         ]
     }
     // ...

--- a/utils/columnAccessor.js
+++ b/utils/columnAccessor.js
@@ -1,10 +1,14 @@
 import { format, timeFormat } from "d3";
+import moment from 'moment';
+import momentDuration from 'moment-duration-format';
+
+momentDuration(moment);
 
 const d3 = { format, timeFormat };
 
 // Compute accessor functions that apply number and date formatters.
 // Useful for presenting numbers in tables or tooltips.
-const columnAccessor = ({ column, format, timeFormat, totalCharacters }) => {
+const columnAccessor = ({ column, format, timeFormat, totalCharacters, duration }) => {
 
     // Generate the accessor for nested values (e.g. "foo.bar").
     const keys = column.split(".");
@@ -45,8 +49,10 @@ const columnAccessor = ({ column, format, timeFormat, totalCharacters }) => {
                         : parsedData
                 )
         }
+    } else if (duration) {
+        return (d) => moment.duration(value(d)).format(duration);
     } else {
-        return value
+        return value;
     }
 };
 


### PR DESCRIPTION
@natabal @bmukheja 

Fix duration time zone format issue #140. Please have a look.
Now you may set desired time format by using `duration` property in the tooltip instead of  the `timeFormat` property. E.g - 

`{ "column": "timestamp", "label": "Value", "duration": "h [hrs], m [min], s [sec]"}`

Note: update the readme docs.
Dependent PR - https://github.com/nuagenetworks/vsd-react-ui/pull/2681