### PR TITLE
VSD-24399: fixed table header

### DIFF
--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -1079,6 +1079,7 @@ class Table extends AbstractGraph {
                                 tableRowColumnStyle={Object.assign({}, style.rowColumn, {fontSize: this.state.fontSize}, tableRowColumnStyle ? tableRowColumnStyle : {})}
                                 tableBodyStyle={Object.assign({}, style.body, {height: `${height - heightMargin}px`})}
                                 footerToolbarStyle={style.footerToolbar}
+                                fixedHeader={true}
                             />
                         }
                 </div>


### PR DESCRIPTION
- Table header row becomes fixed with this change

Sample:
Before:
![tableb4](https://user-images.githubusercontent.com/24920919/59138979-0d46c000-8945-11e9-87c1-5b3792ee3d6b.gif)

After:
![tableafter](https://user-images.githubusercontent.com/24920919/59139028-57c83c80-8945-11e9-8067-281b0f724c83.gif)

