### PR TITLE
Revert "Merge pull request #164 from killanch/tableheader"

### DIFF
--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -1079,7 +1079,6 @@ class Table extends AbstractGraph {
                                 tableRowColumnStyle={Object.assign({}, style.rowColumn, {fontSize: this.state.fontSize}, tableRowColumnStyle ? tableRowColumnStyle : {})}
                                 tableBodyStyle={Object.assign({}, style.body, {height: `${height - heightMargin}px`})}
                                 footerToolbarStyle={style.footerToolbar}
-                                fixedHeader={true}
                             />
                         }
                 </div>


### PR DESCRIPTION
This reverts commit 3232575270f16448235576a1785174012f357369

Noticed that fixedHeader prop causes column alignment issues. Hence reverting.

With fixedHeader:
<img width="1130" alt="Screen Shot 2019-06-10 at 3 34 52 PM" src="https://user-images.githubusercontent.com/24920919/59231530-d0bdd300-8b95-11e9-9338-43884b19c98a.png">

Without fixedHeader:
<img width="1127" alt="Screen Shot 2019-06-10 at 3 34 20 PM" src="https://user-images.githubusercontent.com/24920919/59231511-c0a5f380-8b95-11e9-8f10-17948bf17e07.png">

Hence backing out the recent commit.

