### PR TITLE
Chordgraph - tooltip for only one direction

### DIFF
--- a/Graphs/ChordGraph/default.config.js
+++ b/Graphs/ChordGraph/default.config.js
@@ -6,5 +6,6 @@ export const properties = {
     transitionDuration: 500,
     defaultOpacity: 0.6,
     fadedOpacity: 0.1,
-    chartWidthToPixel: 6
+    chartWidthToPixel: 6,
+    bidirectionalTooltip: true
 }

--- a/Graphs/ChordGraph/index.js
+++ b/Graphs/ChordGraph/index.js
@@ -36,7 +36,7 @@ export default class ChordGraph extends AbstractGraph {
       if(!this.chordDiagram) {
         this.chordDiagram = ChordDiagram(this.svg);
 
-        const { tooltip } = this.getConfiguredProperties();
+        const { tooltip, bidirectionalTooltip = true } = this.getConfiguredProperties();
 
         const { accessor, label } = (
             (tooltip && tooltip.length === 1)
@@ -63,11 +63,13 @@ export default class ChordGraph extends AbstractGraph {
                             <span> {accessor({ value: sourceValue})}</span>
                             { label ? <span> {label}</span>:null }
                         </div>
-                        <div>
-                            <strong>{`${source} to ${destination}:`}</strong>
-                            <span> {accessor({ value: destinationValue})}</span>
-                            { label ? <span> {label}</span>:null }
-                        </div>
+                        {bidirectionalTooltip &&
+                            <div>
+                                <strong>{`${source} to ${destination}:`}</strong>
+                                <span> {accessor({ value: destinationValue})}</span>
+                                { label ? <span> {label}</span>:null }
+                            </div>
+                        }
                     </React.Fragment>
                 );
             } else {

--- a/Graphs/ChordGraph/index.js
+++ b/Graphs/ChordGraph/index.js
@@ -11,6 +11,14 @@ import {properties} from "./default.config"
 
 const MAX_LABEL_LENGTH = 15;
 
+const renderTooltipContent = (source, destination, value, accessor, label) => (
+    <div>
+        <strong>{`${source} to ${destination}:`}</strong>
+        <span> {accessor({value})}</span>
+        {label ? <span> {label}</span>:null}
+    </div>
+);
+
 export default class ChordGraph extends AbstractGraph {
     chordDiagram = null;
 
@@ -36,7 +44,7 @@ export default class ChordGraph extends AbstractGraph {
       if(!this.chordDiagram) {
         this.chordDiagram = ChordDiagram(this.svg);
 
-        const { tooltip, bidirectionalTooltip = true } = this.getConfiguredProperties();
+        const { tooltip, bidirectionalTooltip } = this.getConfiguredProperties();
 
         const { accessor, label } = (
             (tooltip && tooltip.length === 1)
@@ -58,18 +66,8 @@ export default class ChordGraph extends AbstractGraph {
 
                 return (
                     <React.Fragment>
-                        <div>
-                            <strong>{`${destination} to ${source}:`}</strong>
-                            <span> {accessor({ value: sourceValue})}</span>
-                            { label ? <span> {label}</span>:null }
-                        </div>
-                        {bidirectionalTooltip &&
-                            <div>
-                                <strong>{`${source} to ${destination}:`}</strong>
-                                <span> {accessor({ value: destinationValue})}</span>
-                                { label ? <span> {label}</span>:null }
-                            </div>
-                        }
+                        {renderTooltipContent(destination, source, sourceValue, accessor, label)}
+                        {bidirectionalTooltip && renderTooltipContent(source, destination, destinationValue, accessor, label)}
                     </React.Fragment>
                 );
             } else {

--- a/Graphs/ChordGraph/index.js
+++ b/Graphs/ChordGraph/index.js
@@ -11,9 +11,9 @@ import {properties} from "./default.config"
 
 const MAX_LABEL_LENGTH = 15;
 
-const renderTooltipContent = (source, destination, value, accessor, label) => (
+const renderTooltipContent = (from, to, value, accessor, label) => (
     <div>
-        <strong>{`${source} to ${destination}:`}</strong>
+        <strong>{`${from} to ${to}:`}</strong>
         <span> {accessor({value})}</span>
         {label ? <span> {label}</span>:null}
     </div>

--- a/README.md
+++ b/README.md
@@ -450,6 +450,8 @@ __defaultOpacity__ -  Default opacity. Default is `0.6`
 
 __fadedOpacity__ - Hovered opacity. Default is `0.1`
 
+__bidirectionalTooltip__ - Indicates if tooltip needs to display content corresponding to both directions. Default is `true`
+
 ## *SimpleTextGraph*
 This graph allows you to display a simple text information.
 


### PR DESCRIPTION
@nxanil @natabal  We have a scenario where tooltip content should show values corresponding to one direction only. Pls check if ok.

Config without bidirectionalTooltip property (default behavior):
<img width="464" alt="Screen Shot 2019-06-13 at 9 06 14 AM" src="https://user-images.githubusercontent.com/24920919/59448697-91bc9700-8dba-11e9-8105-1825f17211ea.png">

Config with bidirectionalTooltip set to false:
<img width="461" alt="Screen Shot 2019-06-13 at 9 07 08 AM" src="https://user-images.githubusercontent.com/24920919/59448744-aac54800-8dba-11e9-9e2d-494fb3c603be.png">
