### PR TITLE
SimpleTextGraph - customText

### DIFF
--- a/Graphs/SimpleTextGraph/default.config.js
+++ b/Graphs/SimpleTextGraph/default.config.js
@@ -15,6 +15,5 @@ export const properties = {
     defaultFontSize: "25px",
     fontColor: theme.palette.whiteColor,
     innerWidth: 0.4,
-    innerHeight: 0.4,
-    enableTitleInText: true
+    innerHeight: 0.4
 }

--- a/Graphs/SimpleTextGraph/default.config.js
+++ b/Graphs/SimpleTextGraph/default.config.js
@@ -15,5 +15,5 @@ export const properties = {
     defaultFontSize: "25px",
     fontColor: theme.palette.whiteColor,
     innerWidth: 0.4,
-    innerHeight: 0.4
+    innerHeight: 0.4,
 }

--- a/Graphs/SimpleTextGraph/default.config.js
+++ b/Graphs/SimpleTextGraph/default.config.js
@@ -16,4 +16,5 @@ export const properties = {
     fontColor: theme.palette.whiteColor,
     innerWidth: 0.4,
     innerHeight: 0.4,
+    enableTitleInText: true
 }

--- a/Graphs/SimpleTextGraph/index.js
+++ b/Graphs/SimpleTextGraph/index.js
@@ -92,7 +92,7 @@ class SimpleTextGraph extends AbstractGraph {
         return "Untitled";
     }
 
-    renderTitleIfNeeded(requestedPosition, currentPosition) {
+    renderTitleIfNeeded(requestedPosition, currentPosition, title) {
         const { labelFontSize } = this.getConfiguredProperties();
         if (requestedPosition !== currentPosition)
             return;
@@ -100,7 +100,7 @@ class SimpleTextGraph extends AbstractGraph {
         return (
             <div className="simpleText"
             style={{ fontSize: labelFontSize, marginBottom: 10, textAlign: 'center' }}>
-                {this.currentTitle()}
+                {title !== undefined ? title : this.currentTitle()}
             </div>
         );
     }
@@ -136,7 +136,7 @@ class SimpleTextGraph extends AbstractGraph {
         padding,
         targetedColumn,
         titlePosition,
-        enableTitleInText
+        customText
     }) => {
         return (
             <div style={{
@@ -163,7 +163,7 @@ class SimpleTextGraph extends AbstractGraph {
                     whiteSpace: 'nowrap',
                 }}>
                     {this.displayText(data, targetedColumn)}
-                    {enableTitleInText && this.renderTitleIfNeeded(titlePosition, "bottom")}
+                    {this.renderTitleIfNeeded(titlePosition, "bottom", customText)}
                 </div>
             </div>
         );

--- a/Graphs/SimpleTextGraph/index.js
+++ b/Graphs/SimpleTextGraph/index.js
@@ -135,7 +135,8 @@ class SimpleTextGraph extends AbstractGraph {
         data,
         padding,
         targetedColumn,
-        titlePosition
+        titlePosition,
+        enableTitleInText
     }) => {
         return (
             <div style={{
@@ -162,7 +163,7 @@ class SimpleTextGraph extends AbstractGraph {
                     whiteSpace: 'nowrap',
                 }}>
                     {this.displayText(data, targetedColumn)}
-                    {this.renderTitleIfNeeded(titlePosition, "bottom")}
+                    {enableTitleInText && this.renderTitleIfNeeded(titlePosition, "bottom")}
                 </div>
             </div>
         );

--- a/Graphs/SimpleTextGraph/index.js
+++ b/Graphs/SimpleTextGraph/index.js
@@ -100,7 +100,7 @@ class SimpleTextGraph extends AbstractGraph {
         return (
             <div className="simpleText"
             style={{ fontSize: labelFontSize, marginBottom: 10, textAlign: 'center' }}>
-                {title !== undefined ? title : this.currentTitle()}
+                {(title !== undefined && title !== null) ? title : this.currentTitle()}
             </div>
         );
     }

--- a/README.md
+++ b/README.md
@@ -481,6 +481,8 @@ __innerWidth__ - Define the percentage of the width for the area. `1` means 100%
 
 __innerHeight__ - Define the percentage of the height for the area. `1` means 100% of the width. Default is `0.4`
 
+__enableTitleInText__ - Specify if graph title is to be displayed within the text section. Default is `true`
+
 ## *VariationTextGraph*
 This graph shows a value and its variation from the previous one.
 

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ __innerWidth__ - Define the percentage of the width for the area. `1` means 100%
 
 __innerHeight__ - Define the percentage of the height for the area. `1` means 100% of the width. Default is `0.4`
 
-__enableTitleInText__ - Specify if graph title is to be displayed within the text section. Default is `true`
+__customText__ - Additional text to be displayed along with the primary text. If not provided, title will be used in its place
 
 ## *VariationTextGraph*
 This graph shows a value and its variation from the previous one.


### PR DESCRIPTION
- Request from PLM to not show redundant title within text
- 'enableTitleInText' prop used to disable title

Sample:
Before:
<img width="1112" alt="B4" src="https://user-images.githubusercontent.com/24920919/59466817-13281f80-8de3-11e9-8fc2-d8290df50015.png">

After (with enableTitleInText set as false):
<img width="1114" alt="After" src="https://user-images.githubusercontent.com/24920919/59466836-1f13e180-8de3-11e9-952e-266d846e8101.png">
