### PR TITLE
VSD-35412 - fix columnField in table filter

### DIFF
--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -385,7 +385,7 @@ class Table extends AbstractGraph {
                         label: columnRow.label || columnRow.column,
                         sortable: columnRow.sort !== false,
                         columnText: columnRow.selection ? "" : (columnRow.label || columnRow.column),
-                        columField: index,
+                        columnField: index,
                         filter: columnRow.filter !== false,
                         type: columnRow.selection ? "selection" : "text",
                         style: {

--- a/README.md
+++ b/README.md
@@ -595,11 +595,11 @@ __filters__ - List down columns in search bar
 "filters": [
             {
                 "columnText": "name",
-                "columField": "nsgatewayName",
+                "columnField": "nsgatewayName",
                 "type": "text"
             },
             {
-                "columField": "status",
+                "columnField": "status",
                 "type": "selection" // for `selection`, value of status field should be string
             }
 

--- a/SearchBar/AutoCompleteHandler.js
+++ b/SearchBar/AutoCompleteHandler.js
@@ -12,12 +12,12 @@ export default class AutoCompleteHandler extends GridDataAutoCompleteHandler {
     }
 
     needValues(parsedCategory, parsedOperator) {
-        const found = _.find(this.options, f => f.columField === parsedCategory || f.columnText === parsedCategory);
+        const found = _.find(this.options, f => f.columnField === parsedCategory || f.columnText === parsedCategory);
 
         if (found === null) {
             return [];
         }
-        const parsedField = found.columField;
+        const parsedField = found.columnField;
 
         if (found.type === "selection" && this.data !== null) {
             if (!this.cache[parsedField]) {


### PR DESCRIPTION
- react filter box expects `columnField`, but we were using `columField`, because of which search was not successful