### PR TITLE
VariationTextGraph - config option to not display percentage

### DIFF
--- a/Graphs/VariationTextGraph/default.config.js
+++ b/Graphs/VariationTextGraph/default.config.js
@@ -41,4 +41,5 @@ export const properties = {
         },
         iconBox: theme.palette.greenDarkColor
     },
+    showVariation: true
 }

--- a/Graphs/VariationTextGraph/index.js
+++ b/Graphs/VariationTextGraph/index.js
@@ -145,6 +145,7 @@ export class VariationTextGraph extends AbstractGraph {
 
         const {
             absolute,
+            showVariation
         } = this.getConfiguredProperties();
 
         const {
@@ -159,15 +160,15 @@ export class VariationTextGraph extends AbstractGraph {
         return (
 
             <div style={{height: "100%"}}>
-                <span style={Object.assign({}, style.infoBoxIcon, this.settings.colors.iconBox ? {backgroundColor: this.settings.colors.iconBox} : {})}>
+                {showVariation && <span style={Object.assign({}, style.infoBoxIcon, this.settings.colors.iconBox ? {backgroundColor: this.settings.colors.iconBox} : {})}>
                     <div style={Object.assign({}, style.iconFont, (context && context.hasOwnProperty("fullScreen")) ? style.fullScreenLargerFont : {})}>
                         <div style={Object.assign({}, style.labelText, fullScreenFont)}>
                             { this.renderIcon(this.settings.icon) } <br/>
                             {`${this.decimals(this.settings.values.variation)}%`}
                         </div>
                     </div>
-                </span>
-                <span style={Object.assign({}, style.infoBoxText, fullScreenFont)}>
+                </span>}
+                <span style={Object.assign({}, showVariation ? style.infoBoxText : style.infoBoxTextNoVariation, fullScreenFont)}>
                     <span style={{ color: this.settings.colors.content, margin:"auto" }}>
                         { info || info === 0 ? info : 'NaN'}
                     </span>

--- a/Graphs/VariationTextGraph/styles.js
+++ b/Graphs/VariationTextGraph/styles.js
@@ -1,3 +1,13 @@
+const infoBoxTextNoVariation = {
+    borderRadius: "2px 0 0 2px",
+    display: "flex",
+    height: "100%",
+    fontWeight: "bold",
+    fontSize: "1.2em",
+    alignItems: "center",
+    textAlign: "center"
+}
+
 const style = {
     infoBoxIcon: {
         float: "left",
@@ -10,27 +20,14 @@ const style = {
         fontSize: "2em"
     },
 
+    infoBoxTextNoVariation,
+
     infoBoxText: {
-        borderRadius: "2px 0 0 2px",
-        display: "flex",
+        ...infoBoxTextNoVariation,
         float: "right",
-        height: "100%",
         width: "60%",
-        textAlign: "center",
-        fontWeight: "bold",
-        alignItems: "center",
-        fontSize: "1.2em"
     },
-
-    infoBoxTextNoVariation: {
-        borderRadius: "2px 0 0 2px",
-        display: "flex",
-        height: "100%",
-        fontWeight: "bold",
-        fontSize: "1.2em",
-        alignItems: "center",
-    },
-
+    
     labelText: {
         textAlign: "center",
         fontWeight: "bold",

--- a/Graphs/VariationTextGraph/styles.js
+++ b/Graphs/VariationTextGraph/styles.js
@@ -22,6 +22,15 @@ const style = {
         fontSize: "1.2em"
     },
 
+    infoBoxTextNoVariation: {
+        borderRadius: "2px 0 0 2px",
+        display: "flex",
+        height: "100%",
+        fontWeight: "bold",
+        fontSize: "1.2em",
+        alignItems: "center",
+    },
+
     labelText: {
         textAlign: "center",
         fontWeight: "bold",

--- a/README.md
+++ b/README.md
@@ -502,6 +502,8 @@ __fontSize__ - Font size
 
 __fontColor__ - Font color
 
+__showVariation__ - Display percentage variation. Default is `true`
+
 ## *HeatmapGraph*
 This graph shows a value of a column at given timestamp.
 It is a graphical representation of data where the individual values contained in a matrix are represented as colors


### PR DESCRIPTION
Sample: The visualization on the right uses showVariation false and absolute true,
 
<img width="385" alt="Screen Shot 2019-06-21 at 2 29 17 PM" src="https://user-images.githubusercontent.com/24920919/59952632-c3c09f80-9431-11e9-865c-51010086ae34.png">

This is to be used in one of the wifi visualizations.
I do not have a set up right now.