### PR TITLE
ProgressBarGraph: do not update data, use unit from data

### DIFF
--- a/Graphs/ProgressBarGraph/index.js
+++ b/Graphs/ProgressBarGraph/index.js
@@ -41,7 +41,7 @@ export default class ProgressBarGraph extends AbstractGraph {
 
         barData[usedData] = d3.format(maxDataFormat)(barData[usedData]);
         barData[maxData] = barData[maxData] ? d3.format(maxDataFormat)(barData[maxData]) : undefined;
-        const dataUnits = units || barData['unit'] ? ` ${units||barData['unit']}` : '';
+        const dataUnits = barData['unit'] || units ? ` ${barData['unit']||units}` : '';
 
         return barData[maxData] ? `${barData[usedData]}${dataUnits}/ ${barData[maxData]}${dataUnits}` : `${barData[usedData]}${dataUnits}/ ${defaultRange}${dataUnits}`;
     }

--- a/Graphs/ProgressBarGraph/index.js
+++ b/Graphs/ProgressBarGraph/index.js
@@ -23,7 +23,8 @@ export default class ProgressBarGraph extends AbstractGraph {
         return barData[maxData] ? width * barData[usedData] / barData[maxData] : width * barData[usedData] * 0.01;
     }
 
-    getData = (barData) => {
+    getData = (dataFromProps) => {
+        const barData = {...dataFromProps};
         const {
             maxData,
             usedData,
@@ -40,7 +41,7 @@ export default class ProgressBarGraph extends AbstractGraph {
 
         barData[usedData] = d3.format(maxDataFormat)(barData[usedData]);
         barData[maxData] = barData[maxData] ? d3.format(maxDataFormat)(barData[maxData]) : undefined;
-        const dataUnits = units ? ' ' + units : '';
+        const dataUnits = units || barData['unit'] ? ` ${units||barData['unit']}` : '';
 
         return barData[maxData] ? `${barData[usedData]}${dataUnits}/ ${barData[maxData]}${dataUnits}` : `${barData[usedData]}${dataUnits}/ ${defaultRange}${dataUnits}`;
     }


### PR DESCRIPTION
Two changes,
1. data was being overwritten in getData() - use spread operator to deepclone
2. use units from data - let me know if this is ok, else I shall set MB as units in configuration, and update the tabify function in nsgDiskUsage.js to send values converted to MB

Sample:
<img width="369" alt="Screen Shot 2019-06-24 at 5 33 17 PM" src="https://user-images.githubusercontent.com/24920919/60060759-0ccd5980-96a7-11e9-91c3-ff37a2f8aa0c.png">
 