### PR TITLE
[feature]: add dynamic columns

### DIFF
--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -200,12 +200,15 @@ class Table extends AbstractGraph {
          * On data change, resetting the paging and filtered data to 1 and false respectively.
          */
         this.resetFilters((currentPage || 1), this.selectedRows);
-
+        const filterColumns = this.getColumnByContext(columns);
         this.removedColumns = [];
 
-        // remove un-selected columns
         columns.forEach((d, index) => {
-            if (selectedColumns && selectedColumns.length) {
+            if (filterColumns.length) {
+                if (!filterColumns.find(column => d.column === column))
+                    this.removedColumns.push(`${index}`)
+
+            } else if (selectedColumns && selectedColumns.length) {
                 if (!selectedColumns.find(column => d.label === column)) {
                     this.removedColumns.push(`${index}`)
                 }
@@ -215,6 +218,25 @@ class Table extends AbstractGraph {
         });
         this.updateData();
     }
+
+    // update column dynamically according to the value passed through the context
+    getColumnByContext(columns) {
+        const { context } = this.props;
+        const filterColumns = []
+        columns.forEach((d, index) => {
+            if (d.displayOption) {
+                for(let key in d.displayOption) {
+                    if(context.hasOwnProperty(key)) {
+                        this.removedColumnsKey = context[key];
+                        if(context[key] === d.displayOption[key]) {
+                            filterColumns.push(d.column);
+                        }
+                    }   
+                }
+            }
+        })
+        return filterColumns.length ? filterColumns : [];
+    }    
 
     isScrollExpired() {
         const {

--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ __columns__ - (Array) Array of columns display in the table. Example -
             "totalCharacters": 16, // show number of characters for column value
             "tooltip": {"column": "nuage_metadata.subnetName"}, // show tooltip on column values
             "fontColor": "red" // set the font color of the column value
+            "displayOption": {"app": "facebook", "nsg": "ovs-1"} // if request parameter (context) contain any key-value of displayOption then only show given columns.
         }
     ]
 ```


### PR DESCRIPTION
@natabal 
Add the feature to display the table column dynamically.
To enable this feature, add the event listener (queryparams) key-value in the array of the column object (`displayOption`) in the setting as given below: 
`
 "columns": [

            { "column": "gatewayName", "label": "NSG", "displayOption": {"app": "facebook", "nsg": "ovs-1"} },

            { "column": "address","totalCharacters":50, "label": "Address" },
        ]`

So, in above `displayOption` if any event listener has a value `app=facebook` or `nsg=ovs-1` then this column `gatewayName` will be displayed on the table.

Please let me know if I am missing anything.

Note: This PR is created from the base PR `fix-MUI-vulnerabilityIssue`

`

