### PR TITLE
Table search bar:  disable auto-search

### DIFF
--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -698,6 +698,7 @@ class Table extends AbstractGraph {
         const {
             searchBar,
             searchText,
+            autoSearch
         } = this.getConfiguredProperties();
 
         if(searchBar === false)
@@ -714,6 +715,7 @@ class Table extends AbstractGraph {
                 handleSearch={this.handleSearch}
                 columns={this.getColumns()}
                 scroll={this.props.scroll}
+                autoSearch={autoSearch}
             />
         );
     }


### PR DESCRIPTION
@nxanil This is for the 5.4 branch with minor changes I made. Please have a look.

Table search bar to support manually triggering the search once the user is typing the query to search for