### PR TITLE
R6.0: legends for Port Graphs, tooltip on the right, margin for the l…

### DIFF
--- a/Graphs/AbstractGraph.js
+++ b/Graphs/AbstractGraph.js
@@ -64,7 +64,7 @@ export default class AbstractGraph extends React.Component {
             this.tooltip = (
                 <ReactTooltip
                     id={this.tooltipId}
-                    place="top"
+                    place="right"
                     type="dark"
                     effect="float"
                     getContent={[() => this.getTooltipContent(this.hoveredDatum), 200]}
@@ -558,6 +558,7 @@ export default class AbstractGraph extends React.Component {
         } = this.getGraphDimension(label, data);
 
         const legendContainerStyle = {
+            marginLeft: '5px',
             width: legendWidth,
             height: legendHeight,
             display: this.checkIsVerticalLegend() ? 'grid' : 'inline-block',

--- a/Graphs/PortGraph/index.js
+++ b/Graphs/PortGraph/index.js
@@ -88,7 +88,7 @@ class PortGraph extends XYGraph {
     }
 
     // Get the color of the port icons based on the field's value set in configuration.
-    getIconColor(row) {
+    getIconColor = (row) => {
         const {
             portColor,
             defaultIconColor
@@ -296,13 +296,32 @@ class PortGraph extends XYGraph {
         if (!data.length) {
             return this.renderMessage('No data to visualize');
         }
+        const { legend } = this.getConfiguredProperties();
+        const legendData = legend && legend.getData ? evalExpression(legend.getData)(data) : data;
+        const legendGetColor = legend && legend.getColor ? evalExpression(legend.getColor) : this.getIconColor;
+        const legendGetLabel = legend && legend.getLabel ? evalExpression(legend.getLabel) : (d) => (d);
+        const isVertical = this.checkIsVerticalLegend();
+        const {
+            graphHeight,
+            graphWidth,
+        } = this.getGraphDimension(legendGetLabel, legendData);
+
+        const graphStyle = {
+            ...styles.container,
+            width: graphWidth,
+            height: graphHeight,
+            order:isVertical ? 2 : 1,
+        };
 
         return (
             <div className='port-graph'>
                 <div>{this.tooltip}</div>
-                <div style={{ width, height, ...styles.container }}>
-                    {this.renderColumns()}
-                    {this.renderGraph()}
+                <div style={{ height, width,  display: isVertical ? 'flex' : 'inline-grid'}}>
+                    {this.renderLegend(legendData, legend, legendGetColor, legendGetLabel, isVertical) }
+                    <div className='graphContainer' style={graphStyle}>
+                        {this.renderColumns()}
+                        {this.renderGraph()}
+                    </div>
                 </div>
             </div>
         )

--- a/Graphs/PortGraph/styles.js
+++ b/Graphs/PortGraph/styles.js
@@ -14,14 +14,13 @@ const styles = {
         width: '100%',
         display: 'flex',
         flexWrap: 'wrap',
-        fontSize: '.8em'
+        fontSize: '.7em'
     },
     labelRow: {
         width: '100%',
         display: 'flex',
         overflow: 'hidden',
-        listStyle: 'none',
-        padding: '0.6em 1em'
+        listStyle: 'none'
     },
     labelBox: {
         padding: '2px'


### PR DESCRIPTION
…egends (#303)

* Port tooltip upgrade, VSD-32168

* Update README, VSD-32168

* Adjust the legend to add a small margin, update tooltip to pop on the right side of the item. PROD-10427

* Add legend for Port graph, PROD-10427.