### PR TITLE
[Fix]: Area graph tooltip issue

### DIFF
--- a/GraphsV2/AreaGraph/index.js
+++ b/GraphsV2/AreaGraph/index.js
@@ -68,6 +68,8 @@ const AreaGraph = (props) => {
         isVertical: true
     });
 
+    const customLegendLabel = !!Array.isArray(linesColumn) ? tooltip : null;
+
     return (
         <AreaChart
             width={width}
@@ -119,6 +121,7 @@ const AreaGraph = (props) => {
                 renderLegend({
                     legend,
                     height,
+                    customLegendLabel
                 })
             }
             {

--- a/GraphsV2/Components/utils/AreaTooltip.js
+++ b/GraphsV2/Components/utils/AreaTooltip.js
@@ -29,7 +29,7 @@ const TooltipComponent = (props) => {
     return (
         <Container>
             {!isEmpty(tooltip) && payload && payload.length && Object.entries(payload[0].payload).map((element, index) => {
-                if (element[0] !== xColumn && element[0] !== yColumn && element[0] !== linesColumn) {
+                if (element[0] !== xColumn && element[0] !== linesColumn && (Array.isArray(linesColumn) || element[0] !== yColumn)) {
                     let label = element[0]; 
                     let col = tooltip.find(k => k['column'] === label);
                     let columnFormatter;
@@ -40,17 +40,20 @@ const TooltipComponent = (props) => {
                         col =  tooltip.find(k => k['column'] === yColumn);
                         columnFormatter = columnAccessor(col);
                     }
-                    return (
-                        <Item
-                            key={`tooltip-${index}`}
-                        >
-                            {label} : {columnFormatter(element[1])}
-                        </Item>
-                    )
+                    const tooltipdata = tooltip.filter(ele => ele.column === element[0]);
+                    if (!Array.isArray(linesColumn) || !!tooltipdata.length) {
+                        return (
+                            <Item
+                                key={`tooltip-${index}`}
+                            >
+                                {label} : {columnFormatter(element[1])}
+                            </Item>
+                        )
+                    }
                 }
-                
+
             })}
-            
+
         </Container>
     )
 }

--- a/GraphsV2/Components/utils/Legend/StandardLegend.js
+++ b/GraphsV2/Components/utils/Legend/StandardLegend.js
@@ -16,7 +16,7 @@ const Item = styled('div')({
     padding: '0.15rem 0',
 });
 
-export default ({ payload: legends, labelColumn, legend }) => {
+export default ({ payload: legends, labelColumn, legend, customLegendLabel }) => {
     if (legends && legends[0].value === undefined) {
         return false;
     }
@@ -25,10 +25,20 @@ export default ({ payload: legends, labelColumn, legend }) => {
         legends = legends[0].payload.children || [legends[0]];
     }
 
+    if (!!customLegendLabel) {
+        customLegendLabel.forEach(element => {
+            legends.forEach(legend => {
+                if (element.column === legend.value) {
+                    legend.value = element.label;
+                }
+            });
+        });
+    }
+
     return (
         <Container legend={legend}>
             {
-                legends.map(({ color, payload, value, props: { fill, name: { xVal } = {}}={}} , index) => (
+                legends.map(({ color, payload, value, props: { fill, name: { xVal } = {} } = {} }, index) => (
                     <Item key={`legend-${index}`} color={color || fill}>
                         <svg height='0.8rem' width='0.9rem'>
                             <circle cx="7" cy="9" r="3.5" fill={color || fill} />


### PR DESCRIPTION
@natabal 

Fix issue #388. Please have a look.

Please use `lineColumn` in the visualization file like : 

**"linesColumn": ["LossAfterFEC", "NetworkLoss"],** 

![Screenshot from 2020-08-14 20-37-20](https://user-images.githubusercontent.com/26645756/90264395-a852f800-de6e-11ea-9b97-26bcf811368b.png)