### PR TITLE
fix VSD-50716 - progress graph data

### DIFF
--- a/Graphs/ProgressBarGraph/index.js
+++ b/Graphs/ProgressBarGraph/index.js
@@ -21,7 +21,7 @@ const getWidth = (
 }
 
 const getData = ({
-    barData,
+    barData: barDataFromProps,
     maxData,
     usedData,
     display,
@@ -29,6 +29,7 @@ const getData = ({
     defaultRange,
     units
 }) => {
+    const barData = {...barDataFromProps};
 
     if (display === PERCENTAGE) {
         const data = barData[maxData] ? (barData[usedData] * 100) / barData[maxData] : barData[usedData];


### PR DESCRIPTION
- Issue: numerical data from props was being wrongly transformed as string, because of which graph was not being rendered
- fix: ensure that same object from props is not manipulated

Sample:
![Screen Shot 2020-11-16 at 3 06 57 PM](https://user-images.githubusercontent.com/24920919/99319233-056b9a80-281e-11eb-9295-f614f303b4a1.png)
