### PR TITLE
Table - fix exception when column data is object

### DIFF
--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -336,7 +336,14 @@ const TableGraph = (props) => {
             <Column
                 label={column.label}
                 dataKey={(column.columnField)}
-                cellDataGetter={({ dataKey, rowData }) => get(rowData, dataKey)}
+                cellDataGetter={({ dataKey, rowData }) => {
+                    let data = get(rowData, dataKey);
+                    // In certain cases, data is processed incorrectly and the value is an object.
+                    // We do not support javascript objects to be displayed in a column, but we do support react elements to be displayed
+                    data = typeof(data) === "boolean" ? data.toString().toUpperCase()
+                        : (typeof data === "object") ? React.isValidElement(data) ? data : null : data;
+                    return data;
+                }}
                 headerRenderer={headerRenderer}
                 width={150}
                 cellRenderer={({cellData}) => cellData}


### PR DESCRIPTION
- When value for a column is an object, Table rendering fails with below exception
```
Uncaught Invariant Violation: Objects are not valid as a React child (found: object with keys {Client, doc_count, IP}). If you meant to render a collection of children, use an array instead.
    in div (created by Grid)
    in div (created by Grid)
    in div (created by Grid)
    in div (created by Grid)
    in Grid (created by Table)
    in div (created by Table)
    in Table (at Table/index.js:668)
    in div (created by AutoSizer)
    in AutoSizer (at Table/index.js:665)
    in InfiniteLoader (at Table/index.js:659)
    in div (at Table/index.js:658)
    in div (at Table/index.js:657)
    in div (at Table/index.js:648)
```
- Fix: if object, then render null. this is on par with our r6.0 implementation