### PR TITLE
Table - disable scroll-sort on specific columns

### DIFF
--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -251,6 +251,10 @@ const TableGraph = (props) => {
     }
 
     const handleScrollSorting = (sortBy, sortDirection) => {
+        const selectedColumn = getColumns().find(item => item.column === sortBy);
+        if (!selectedColumn || selectedColumn.sort === false) {
+            return;
+        }
 
         const sort = objectPath.has(scrollData, 'sort') ? objectPath.get(scrollData, 'sort') : undefined;
         if (sort && sort.column === sortBy.toLowerCase()) {


### PR DESCRIPTION
- Addresses https://github.com/nuagenetworks/vis-graphs/issues/440
- disabled scroll-sorting on column if `"sort": false` specified in column configuration
- static-sorting allowed always