### PR TITLE
VSD-51747 onClick error when clicked inside graph area

### DIFF
--- a/Graphs/ChordGraph/Svg.js
+++ b/Graphs/ChordGraph/Svg.js
@@ -37,7 +37,12 @@ export default ({
               <rect
                 fillOpacity={0}
                 height={height}
-                onClick={ (event) => { clearHover(); isFunction(onClick) && onClick(event) } }
+                onClick={(event) => {
+                    clearHover();
+                    if (isFunction(onClick)) {
+                        onClick(event);
+                    }
+                }}
                 width={width}
                 x={`-${width / 2}`}
                 y={`-${height / 2}`}

--- a/Graphs/ChordGraph/Svg.js
+++ b/Graphs/ChordGraph/Svg.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { styled } from '@material-ui/core/styles';
+import { isFunction } from '../../utils/helpers';
 
 const SvgContainer = styled('div')({
     display: 'inline-block',
@@ -36,7 +37,7 @@ export default ({
               <rect
                 fillOpacity={0}
                 height={height}
-                onClick={ (event) => { clearHover(); onClick(event) } }
+                onClick={ (event) => { clearHover(); isFunction(onClick) && onClick(event) } }
                 width={width}
                 x={`-${width / 2}`}
                 y={`-${height / 2}`}


### PR DESCRIPTION
**Issue:** There is no check for `onClick` prop passed on to the Svg component. `ChordGraph` component does not send `onClick` prop and hence there is an error when we click inside the `ChordGraph`. In dev environment the app crashes and in prod a console error is logged.

**Solution:** Add a check for onClick prop.

