### PR TITLE
VSD-51734 - tree view pagination

### DIFF
--- a/Graphs/TreeGraph/index.js
+++ b/Graphs/TreeGraph/index.js
@@ -210,6 +210,8 @@ const TreeGraph = (props) => {
     const isFirst = useRef(true);
     const [nodeElement, setNodeElement] = useState(null);
 
+    const kids = Array.isArray(props.data) && props.data.length ? props.data[0].kids : null;
+
     useEffect(() => {
         if (isFirst.current) {
             isFirst.current = false;
@@ -222,7 +224,7 @@ const TreeGraph = (props) => {
             elementGenerator();
             setDraggingRef(props);
         }
-    },  [props.params, props.data, nodeElement, pageNo]);
+    },  [props.params, props.data, nodeElement, pageNo, kids]);
 
     // Toggle children on click.
     const click = d => {


### PR DESCRIPTION
Issue: Though `kids` within data gets changed, useEffect does not get triggered. This is because of data object shallow diff/comparison
Fix: Pass `kids` explicitly within second array param such that useEffect gets triggered if child nodes data changes

Also required vsd-react-ui change: https://github.com/nuagenetworks/vsd-react-ui/pull/4848

Before:
![treeviewPagination](https://user-images.githubusercontent.com/24920919/106071675-a054e080-60bb-11eb-80a3-adc651d7b58f.gif)

After:
![treeviewPaginationAfter](https://user-images.githubusercontent.com/24920919/106071817-dc884100-60bb-11eb-93a5-210ebf1d38ea.gif)
