### PR TITLE
fix pie graph percentage tooltip

### DIFF
--- a/Graphs/PieGraph/index.js
+++ b/Graphs/PieGraph/index.js
@@ -76,7 +76,7 @@ const PieGraph = (props) => {
                 prev = prev[sliceColumn];
             }
             return prev + cur[sliceColumn];
-        });
+        }, 0);
 
         data.forEach(element => {
             element.percantage = `${(element[sliceColumn] / Total * 100).toFixed(2)}%`;


### PR DESCRIPTION
Issue: If there is only one element in data array, array.reduce will not work unless initial value is provided. Because of this, value of `Total` is not a number

Fix: Set initial value as 0

Before:
<img width="277" alt="Screen Shot 2021-02-22 at 12 56 50 PM" src="https://user-images.githubusercontent.com/24920919/108769466-df851e80-750d-11eb-8529-0d1b072ad512.png">

After:
<img width="278" alt="Screen Shot 2021-02-22 at 12 55 30 PM" src="https://user-images.githubusercontent.com/24920919/108769478-e3b13c00-750d-11eb-8c32-1eac49a62fe1.png">
