### PR TITLE
VSD-52348 - Reposition refresh icon in graphs

### DIFF
--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -553,7 +553,7 @@ const TableGraph = (props) => {
         };
 
         return (
-            <div className={'select-column'} style={{ flex: "none", marginRight: '15px' }}>
+            <div className={'select-column'} style={{ flex: "none" }}>
                 <Select
                     labelId="demo-mutiple-checkbox-label"
                     id="demo-mutiple-checkbox"
@@ -687,11 +687,11 @@ const TableGraph = (props) => {
     const resetScrollData = () => {
         return (
             scroll && !disableRefresh ?
-                <div style={{ flex: "none", marginTop: '-10px', marginRight: selectColumnOption? '-10px' : '10px' }}>
+                <div style={{ flex: "none" }}>
                     <IconButton
                         tooltip="Refresh"
                         tooltipPosition={'top-left'}
-                        style={style.design}
+                        style={style.refresh}
                         onClick={() => props.updateScroll({ currentPage: 1, selectedRow: {}, event: events.REFRESH })}
                     >
                         <RefreshIcon className='refreshIcon' />
@@ -708,7 +708,7 @@ const TableGraph = (props) => {
             <div ref={(input) => { container = input; }}
                 onContextMenu={props.handleContextMenu ? props.handleContextMenu : handleContextMenu}
             >
-                <div style={{ float: 'right', display: 'flex', flexDirection: 'row-reverse'}}>
+                <div style={{ float: 'right', display: 'flex', paddingRight: !disableRefresh ? 10 : 15 }}>
                     {filteredColumnBar(selectColumnOption)}
                     {resetScrollData()}
                 </div>

--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -553,7 +553,7 @@ const TableGraph = (props) => {
         };
 
         return (
-            <div className={'select-column'} style={{ flex: "none" }}>
+            <div className={'select-column'} style={{ flex: "none", marginRight: '15px' }}>
                 <Select
                     labelId="demo-mutiple-checkbox-label"
                     id="demo-mutiple-checkbox"
@@ -687,7 +687,7 @@ const TableGraph = (props) => {
     const resetScrollData = () => {
         return (
             scroll && !disableRefresh ?
-                <div style={{ flex: "none" }}>
+                <div style={{ flex: "none", marginTop: '-10px', marginRight: selectColumnOption? '-10px' : '10px' }}>
                     <IconButton
                         tooltip="Refresh"
                         tooltipPosition={'top-left'}
@@ -708,13 +708,13 @@ const TableGraph = (props) => {
             <div ref={(input) => { container = input; }}
                 onContextMenu={props.handleContextMenu ? props.handleContextMenu : handleContextMenu}
             >
-                <div style={{ float: 'right', display: 'flex', paddingRight: !disableRefresh ? 45 : 20 }}>
-                    {resetScrollData()}
+                <div style={{ float: 'right', display: 'flex', flexDirection: 'row-reverse'}}>
                     {filteredColumnBar(selectColumnOption)}
+                    {resetScrollData()}
                 </div>
                 <div style={{ clear: "both" }}></div>
                 {renderSearchBarIfNeeded(getHeaderData())}
-                <div style={{ overflowX: "auto", paddingTop: '10px' }}>
+                <div style={{ overflowX: "auto" }}>
                     <div style={{ height: graphHeight, minWidth: width }}>
                         <InfiniteLoader
                             isRowLoaded={({ index }) => !!filterData[index]}

--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -714,7 +714,7 @@ const TableGraph = (props) => {
                 </div>
                 <div style={{ clear: "both" }}></div>
                 {renderSearchBarIfNeeded(getHeaderData())}
-                <div style={{ overflowX: "auto" }}>
+                <div style={{ overflowX: "auto", paddingTop: '10px' }}>
                     <div style={{ height: graphHeight, minWidth: width }}>
                         <InfiniteLoader
                             isRowLoaded={({ index }) => !!filterData[index]}

--- a/Graphs/Table/style.js
+++ b/Graphs/Table/style.js
@@ -5,8 +5,8 @@ const tableStyle = {
         maxHeight: '0px',
         maxWidth: '30px',
         padding: '0',
-        top: "40px",
-        right: '10px',
+        top: "45px",
+        right: '-5px',
         position: "fixed"
     }
 }

--- a/Graphs/Table/style.js
+++ b/Graphs/Table/style.js
@@ -8,6 +8,9 @@ const tableStyle = {
         top: "40px",
         right: '10px',
         position: "fixed"
+    },
+    refresh: {
+        marginTop: "-10px",
     }
 }
 

--- a/Graphs/Table/style.js
+++ b/Graphs/Table/style.js
@@ -5,8 +5,8 @@ const tableStyle = {
         maxHeight: '0px',
         maxWidth: '30px',
         padding: '0',
-        top: "45px",
-        right: '-5px',
+        top: "40px",
+        right: '10px',
         position: "fixed"
     }
 }


### PR DESCRIPTION
Issue 2: Refresh icon is overlapping the UL list

Fix 2: Send a cutom style for refresh icon component and adjust the container' div's padding style. Make sure the refresh icon is on the right of the filterColumn dropdown if present

Issue 2: Before fix:
![image](https://user-images.githubusercontent.com/32629188/108976604-8cf65000-763c-11eb-8bef-9f839ebcb411.png)

Issue 2: After fix
![image](https://user-images.githubusercontent.com/32629188/109356681-e70e3580-7835-11eb-87de-15a3b7be23d6.png)
![image](https://user-images.githubusercontent.com/32629188/109356733-f8efd880-7835-11eb-86a0-b0941e30ad1a.png)

After fix with forced filteredColoumn
![image](https://user-images.githubusercontent.com/32629188/109356714-f2f9f780-7835-11eb-9ecc-e6b72c0472f2.png)

