### PR TITLE
VSD-52408 - fix table error on row selection after filter change

### DIFF
--- a/Graphs/Table/index.js
+++ b/Graphs/Table/index.js
@@ -99,7 +99,7 @@ const setSelectedRows = (props) => {
     } = props;
 
     const selectedRows = objectPath.has(scrollData, 'selectedRow') ? objectPath.get(scrollData, 'selectedRow') : [];
-    return !isEmpty(selectedRows) ? selectedRows[requestId] : [];
+    return !isEmpty(selectedRows) ? (selectedRows[requestId] || []) : [];
 }
 
 const TableGraph = (props) => {


### PR DESCRIPTION
- fixes below error
```
TypeError: Cannot read property 'includes' of undefined
onRowClick
src/lib/vis-graphs/Graphs/Table/index.js:414
  411 | 
  412 | const onRowClick = ({ index }) => {
  413 |     let selectedRowsCurr = rowSelected;
> 414 |     if (rowSelected.includes(index)) {
      | ^  415 |         selectedRowsCurr = rowSelected.filter(item => item !== index);
  416 |     } else {
  417 |         selectedRowsCurr = !!multiSelectable ? [...selectedRowsCurr, index] : [index];
```
- if matching `requestId` not available in `selectedRows`, return empty array instead of undefined. this happens if filter value is changed by the user. `requestId` will change with filter value change 