### PR TITLE
Fix VSD 57649 NSG - LTE uplink connection type and status in VSD-A are numeric

### DIFF
--- a/Graphs/Components/utils/yAxis.js
+++ b/Graphs/Components/utils/yAxis.js
@@ -22,7 +22,7 @@ export default ({
     return (
         <YAxis
             type={type}
-            dataKey={type ? yColumn : undefined}
+            dataKey={type ? (Array.isArray(yColumn) ? yColumn[0] : yColumn) : undefined}
             axisLine={{ stroke: '#E9ECF0' }}
             tickLine={false}
             tick={

--- a/Graphs/LineGraph/index.js
+++ b/Graphs/LineGraph/index.js
@@ -43,6 +43,7 @@ const LineGraph = (props) => {
         brushEnabled,
         xTicks,
         graph,
+        type,
         activeDotOnlyTooltip
     } = properties;
 
@@ -116,8 +117,10 @@ const LineGraph = (props) => {
             }
             {
                 yAxis({
+                    yColumn,
                     yLabel,
                     yTickFormat,
+                    type: type,
                     limit: yLabelLimit,
                 })
             }


### PR DESCRIPTION
**Jira:** VSD-57649.

There is another pull request for vsd-react-ui side of fix: https://github.com/nuagenetworks/vsd-react-ui/pull/5455

Since the issue is on uplinkConnection context, I only put the transform data method on that page, so the other pages using metricsGraph and GraphView are not affected.